### PR TITLE
Fix operadores

### DIFF
--- a/syntaxes/lsp.tmLanguage.json
+++ b/syntaxes/lsp.tmLanguage.json
@@ -93,15 +93,15 @@
 			"patterns": [
 				{
 					"name": "keyword.operator.arithmetic.lsp",
-      		"match": "(?<!\\.)(?i)\\b(\\+|-|\\*|/|=|\\+\\+|--)\\b"
+					"match": "(?<!\\.)\\+|-|\\*|/|=|\\+\\+|--"
 				},
 				{
 					"name": "keyword.operator.lsp",
-					"match": "(?<!\\.)(?i)\\b(e|ou)\\b"
+					"match": "(?<!\\.)\\b(e|ou)\\b"
 				},
 				{
 					"name": "keyword.operator.logical.lsp",
-					"match": "(?<!\\.)(?i)\\b(=|>|<|<>|>=|<=|e|ou)\\b"
+					"match": "(?<!\\.)\\b(=|>|<|<>|>=|<=|e|ou)\\b"
 				}				
 			]
 		},


### PR DESCRIPTION
Arrumada a situação dos operadores não mudarem de cor quando há um espaço precedente ou subsequente.

Antes:
![image](https://github.com/rodrigokiller/vscode-language-lsp/assets/124214754/b6ca51d9-9e9f-403c-a762-08ba7912bb59)

Depois:
![image](https://github.com/rodrigokiller/vscode-language-lsp/assets/124214754/7ebe2de9-b210-4bb7-b3fa-a450643959fc)

