### PR TITLE
Alterações inicio-fim e comentários;

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -10,16 +10,15 @@
         ["{", "}"],
         ["[", "]"],
         ["(", ")"],
-        ["Inicio", "Fim"],
-        ["Inicio", "Fim;"]
+        ["/*", "*/"]
     ],
     // symbols that are auto closed when typing
     "autoClosingPairs": [
         ["{", "}"],
         ["[", "]"],
         ["(", ")"],
-        ["Inicio", "Fim"],
-        ["Inicio", "Fim;"]
+        ["@ ", " @"],
+        ["/*", "*/"],
         { "open": "\"", "close": "\"", "notIn": ["string"] }
     ],
     // symbols that can be used to surround a selection
@@ -27,6 +26,7 @@
         ["{", "}"],
         ["[", "]"],
         ["(", ")"],
+        ["@ ", " @"],
         { "open": "\"", "close": "\"", "notIn": ["string"] },
         { "open": "{", "close": "}", "notIn": ["string"] }
     ]

--- a/snippets/lsp.json
+++ b/snippets/lsp.json
@@ -1,4 +1,28 @@
 {
+  "inicio": {
+    "prefix": "inicio",
+    "body": [
+      "inicio",
+        "\t$2",
+      "fim;"
+    ],
+    "description": "bloco de comandos inicio - fim"
+  },
+
+  "inicio senao": {
+    "prefix": "inicio",
+    "body": [
+      "inicio",
+        "\t$2",
+      "fim",
+      "senao",
+      "inicio",
+        "\t$3",
+      "fim;"
+    ],
+    "description": "bloco de comandos inicio - fim com senão"
+  },
+  
   "para": {
     "prefix": "para",
     "body": [


### PR DESCRIPTION
02/05/2024: Alterações e ajustes feitos por @Nelson-Capello:

# NOVOS RECURSOS e COMO USAR:

- novo auxílio para comentários:
  - pode usar @ espaço que vai completar; se tiver controle de versão (GitHub), vai ser sugerido @ menção, pode teclar espaço que funciona; @ menções vão ficar como comentários no LSP, por definição da linguagem;
  - para inserir menções em comentários, vai teclar: @ espaço, @ escolher_menção; se não teclar duas vezes o @, a menção é inserida porém o final do comentário de linha não é;
  - pode usar /*espaço que vai completar, blocar, identar e posicionar;
  - pode marcar a(s) palavra(s) e usar @, que vai por no inicio e no fim (envolver); se quiser com espaços antes e depois, tem que inserir manualmente, os espaços não inserem automáticamente;
- nova funcionalidade para inicio e fim:
  - mudou para lower case e agora é um snippet, assim o auxílio dispara sem precisar capitalizar a primeira letra da palavra, e continua sempre disparando independente da sugestão de "inicio" que o VSCode passa a sugerir depois que utilizou a palavra uma vez, o que quebrava o funcionamento do inicio - fim como auto-close;
  - o snippet contempla [inicio - fim], e [inicio - fim - senao - inicio - fim], e com TAB posiciona nos locais de edição e também no fim do bloco;